### PR TITLE
Fixing tests and setting up Alchemy's deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 build/
 generated/
+tests/.bin
+tests/.docker
+tests/.latest.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ generated/
 tests/.bin
 tests/.docker
 tests/.latest.json
+.env

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ This contract lives in Polygon mainnet:
 
 https://polygonscan.com/address/0x1f5C5fd6A66723fA22a778CC53263dd3FA6851E5
 
+This subgraph has been deployed using [Alchemy subgraphs](https://subgraphs.alchemy.com/).
+
 GraphQL API
+
+> https://subgraph.satsuma-prod.com/735cd3ac7b23/nucypher-ops/PolygonChild/api
 
 ## Running tests
 
@@ -19,4 +23,17 @@ Running the tests requires Docker.
 
 ```bash
 npm run test
+```
+
+## Deploying a new version
+
+It is required an Alchemy's Deployment Key. Look for it in the NuCo Alchemy account.
+Set the deployment key in a `.env` file:
+
+```dotenv
+DEPLOY_KEY=xz.........49
+```
+
+```bash
+npm run deploy
 ```

--- a/README.md
+++ b/README.md
@@ -13,4 +13,10 @@ https://polygonscan.com/address/0x1f5C5fd6A66723fA22a778CC53263dd3FA6851E5
 
 GraphQL API
 
-> https://api.studio.thegraph.com/query/24143/polygonchild/version/latest
+## Running tests
+
+Running the tests requires Docker.
+
+```bash
+npm run test
+```

--- a/package.json
+++ b/package.json
@@ -4,11 +4,7 @@
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-    "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ subgraph-polygonChild",
-    "create-local": "graph create --node http://localhost:8020/ subgraph-polygonChild",
-    "remove-local": "graph remove --node http://localhost:8020/ subgraph-polygonChild",
-    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 subgraph-polygonChild",
-    "test": "graph test"
+    "test": "graph test -d"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.67.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "subgraph-polygonChild",
-  "license": "UNLICENSED",
+  "name": "subgraph-polygonchild",
+  "license": "GPL-3.0-or-later",
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
+    "deploy": "eval $(grep '^DEPLOY_KEY' .env) && graph deploy PolygonChild --node https://subgraphs.alchemy.com/api/subgraphs/deploy --deploy-key ${DEPLOY_KEY} --ipfs https://ipfs.satsuma.xyz",
     "test": "graph test -d"
   },
   "dependencies": {

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -1,4 +1,4 @@
-specVersion: 1.0.0
+specVersion: 0.0.8
 indexerHints:
   prune: auto
 schema:

--- a/tests/polygon-child.test.ts
+++ b/tests/polygon-child.test.ts
@@ -4,43 +4,31 @@ import {
   test,
   clearStore,
   beforeAll,
-  afterAll
-} from "matchstick-as/assembly/index"
-import { Bytes, Address } from "@graphprotocol/graph-ts"
-import { MessageSent } from "../generated/schema"
-import { MessageSent as MessageSentEvent } from "../generated/PolygonChild/PolygonChild"
-import { handleMessageSent } from "../src/polygon-child"
-import { createMessageSentEvent } from "./polygon-child-utils"
-
-// Tests structure (matchstick-as >=0.5.0)
-// https://thegraph.com/docs/en/developer/matchstick/#tests-structure-0-5-0
+  afterAll,
+} from "matchstick-as/assembly/index";
+import { Bytes } from "@graphprotocol/graph-ts";
+import { handleMessageSent } from "../src/polygon-child";
+import { createMessageSentEvent } from "./polygon-child-utils";
 
 describe("Describe entity assertions", () => {
   beforeAll(() => {
-    let message = Bytes.fromI32(1234567890)
-    let newMessageSentEvent = createMessageSentEvent(message)
-    handleMessageSent(newMessageSentEvent)
-  })
+    const message = Bytes.fromI32(1234567890);
+    const newMessageSentEvent = createMessageSentEvent(message);
+    handleMessageSent(newMessageSentEvent);
+  });
 
   afterAll(() => {
-    clearStore()
-  })
-
-  // For more test scenarios, see:
-  // https://thegraph.com/docs/en/developer/matchstick/#write-a-unit-test
+    clearStore();
+  });
 
   test("MessageSent created and stored", () => {
-    assert.entityCount("MessageSent", 1)
+    assert.entityCount("MessageSent", 1);
 
-    // 0xa16081f360e3847006db660bae1c6d1b2e17ec2a is the default address used in newMockEvent() function
     assert.fieldEquals(
       "MessageSent",
-      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-1",
+      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a01000000",
       "message",
-      "1234567890"
-    )
-
-    // More assert options:
-    // https://thegraph.com/docs/en/developer/matchstick/#asserts
-  })
-})
+      Bytes.fromI32(1234567890).toHexString()
+    );
+  });
+});


### PR DESCRIPTION
These changes will fix the tests.

Also, these will set up the deployment script to automatically deploy to Alchemy subgraphs.

The readme has been updated accordingly.

This subgraph has been deployed in Alchemy, so this closes #2 